### PR TITLE
Babel 5.x support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "experimental": true
+    "stage": 0
 }

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Babel has many transform options.
 
 - [Options · Babel](https://babeljs.io/docs/usage/options/ "Options · Babel")
 
-`espower-babel` support babel transform options with `.babelrc`
+`espower-babel` support babel transform options with [.babelrc](http://babeljs.io/docs/usage/babelrc/ "babelrc").
 
 `espower-babel` read `${cwd}/.babelrc` if exists.
 
@@ -158,7 +158,7 @@ also can manually configure babel transform options.
 ```js
 require('espower-babel')({
     babelrc: {
-        experimental: true
+        stage: 0
     }
 })
 ```

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "url": "https://github.com/azu/espower-babel/issues"
   },
   "dependencies": {
-    "babel-core": "^4.7.16",
-    "convert-source-map": "^0.4.1",
+    "babel-core": "^5.0",
+    "convert-source-map": "^1.0.0",
     "espower-source": "^0.10.0",
     "minimatch": "^2.0.1",
     "xtend": "^4.0.0"

--- a/test_loader/espower-traceur-loader.js
+++ b/test_loader/espower-traceur-loader.js
@@ -20,6 +20,6 @@ require('..')({
         ]
     },
     babelrc: {
-      experimental: true
+        stage: 0
     }
 });


### PR DESCRIPTION
- [x] use `--stage 0` instead of `--experimental`
- [x] add [babelrc](http://babeljs.io/docs/usage/babelrc/)
