### PR TITLE
Replace espower-source with babel-plugin-espower

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,8 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "empower": "^0.10.0",
     "expect.js": "^0.3.1",
     "mocha": "^2.1.0",
-    "power-assert": "^0.10.0",
-    "power-assert-formatter": "^0.10.1"
+    "power-assert": "^0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   },
   "dependencies": {
     "babel-core": "^5.0",
-    "convert-source-map": "^1.0.0",
-    "espower-source": "^0.10.0",
+    "babel-plugin-espower": "^0.2.0",
     "minimatch": "^2.0.1",
     "xtend": "^4.0.0"
   },

--- a/test/tobe_instrumented/es7_test.js
+++ b/test/tobe_instrumented/es7_test.js
@@ -6,6 +6,6 @@ describe("ES7 async/await", ()=>{
   it("works", async()=>{
     let ok = await Promise.resolve("OK")
 
-    assert(ok === "OK")
+    assert(`${ok}` === "OK")
   })
 })

--- a/test/tobe_instrumented/tobe_instrumented_test.js
+++ b/test/tobe_instrumented/tobe_instrumented_test.js
@@ -1,6 +1,4 @@
-let empower = require("empower")
-let formatter = require("power-assert-formatter")()
-let assert = empower(require("assert"), formatter)
+let assert = require('power-assert')
 let expect = require("expect.js")
 
 describe("power-assert message", function(){


### PR DESCRIPTION
Hi, I've released [babel-plugin-espower](https://github.com/twada/babel-plugin-espower) yesterday.

babel-plugin-espower works as babel plugin, transforms ES6 tree to espowered ES6 tree. ES6 -> ES5 pre-transpilation is not required any more!
