### PR TITLE
chore(package): update babel-plugin-espower to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "babel-core": "^5.0",
-    "babel-plugin-espower": "^0.2.0",
+    "babel-plugin-espower": "^0.3.0",
     "minimatch": "^2.0.1",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
Hi,

Current test fails on master HEAD.
`babel 5.2.x` internal changes bring this.

See this.
[TypeError: fixtures/Literal/fixture.js: Cannot read property 'key' of undefined](https://github.com/twada/babel-plugin-espower/issues/3)

```
$ npm test

> espower-babel@2.1.0 test /Users/sane/work/js-study/espower-babel
> mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js

/Users/sane/work/js-study/espower-babel/node_modules/babel-core/lib/babel/helpers/parse.js:80
    throw err;
          ^
TypeError: /Users/sane/work/js-study/espower-babel/test/tobe_instrumented/es7_test.js: Cannot read property 'key' of undefined
    at traverseUp (/Users/sane/work/js-study/espower-babel/node_modules/babel-plugin-espower/lib/babel-estree-path.js:6:33)
    at traverseUp (/Users/sane/work/js-study/espower-babel/node_modules/babel-plugin-espower/lib/babel-estree-path.js:18:9)
    at traverseUp (/Users/sane/work/js-study/espower-babel/node_modules/babel-plugin-espower/lib/babel-estree-path.js:18:9)
    at traverseUp (/Users/sane/work/js-study/espower-babel/node_modules/babel-plugin-espower/lib/babel-estree-path.js:18:9)

(snip)
```

My environments.

```
$ node --version
v0.12.2
xtend@4.0.0
expect.js@0.3.1
minimatch@2.0.7
mocha@2.2.4
power-assert@0.11.0
babel-plugin-espower@0.2.2
babel-core@5.2.6
```
