### PR TITLE
Support `mocha --compilers es6:espower-babel/guess`

### DIFF
--- a/guess.js
+++ b/guess.js
@@ -3,13 +3,24 @@ var path = require('path'),
     pattern = 'test/**/*.js',
     packageData,
     testDir,
-    babelrc;
+    babelrc,
+    extension = '.js';
+
+// Override extension via `mocha --compilers <extension>:espower-babel/guess`
+process.argv.forEach(function(arg){
+    if (arg.indexOf(':espower-babel/guess') === -1) {
+        return;
+    }
+
+    extension = '.'+arg.split(':')[0];
+});
+
 packageData = require(path.join(process.cwd(), 'package.json'));
 if (packageData &&
     typeof packageData.directories === 'object' &&
     typeof packageData.directories.test === 'string') {
     testDir = packageData.directories.test;
-    pattern = testDir + ((testDir.lastIndexOf('/', 0) === 0) ? '' : '/') + '**/*.js';
+    pattern = testDir + ((testDir.lastIndexOf('/', 0) === 0) ? '' : '/') + '**/*'+extension;
 }
 
 babelrc = resolveBabelrc(process.cwd(), {});
@@ -17,5 +28,6 @@ babelrc = resolveBabelrc(process.cwd(), {});
 require('./index')({
     cwd: process.cwd(),
     pattern: pattern,
-    babelrc: babelrc
+    babelrc: babelrc,
+    extension: extension
 });

--- a/guess.js
+++ b/guess.js
@@ -6,13 +6,16 @@ var path = require('path'),
     babelrc,
     extension = '.js';
 
-// Override extension via `mocha --compilers <extension>:espower-babel/guess`
+// Override extension via (eg: `mocha --compilers <extension>:espower-babel/guess`)
 process.argv.forEach(function(arg){
-    if (arg.indexOf(':espower-babel/guess') === -1) {
+    var args = arg.split(':');
+    if (args.length <= 1) {
         return;
     }
-
-    extension = '.'+arg.split(':')[0];
+    var path = args[1];
+    if(require.resolve(path) === module.filename) {
+        extension = '.'+arg.split(':')[0];
+    }
 });
 
 packageData = require(path.join(process.cwd(), 'package.json'));

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var extensions = require.extensions,
 function espowerBabel(options) {
     var separator = (options.pattern.lastIndexOf('/', 0) === 0) ? '' : '/',
         pattern = options.cwd + separator + options.pattern,
-        babelrc = options.babelrc || {};
+        babelrc = options.babelrc || {},
+        extension = options.extension || ".js";
 
     var sourceMaps = {};
     // https://github.com/evanw/node-source-map-support
@@ -42,7 +43,7 @@ function espowerBabel(options) {
         return babelOptions;
     }
 
-    extensions[".js"] = function (localModule, filepath) {
+    extensions[extension] = function (localModule, filepath) {
         var result;
         // https://babeljs.io/docs/usage/api/
         var babelOptions = extend(babelrc, {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js"
+    "test": "mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js && mocha test/issues/17 --compilers es6:./guess"
   },
   "directories": {
     "test": "test/"

--- a/test/issues/17/index.es6
+++ b/test/issues/17/index.es6
@@ -1,0 +1,7 @@
+let assert = require('power-assert')
+
+describe("Loaded compiler", ()=>{
+  it("to be defined .es6", ()=>{
+    assert.ok(require.extensions['.es6'])
+  })
+})


### PR DESCRIPTION
`$ mocha --compilers <ext>:espower-babel/guess`とした時だけ、require.extensionsを`.<ext>`に変更します。

現状（`v3.1.1`）、以下の環境では

``` bash
.
├── package.json
├── src
│   └── index.es6
└── test
    └── index.es6
```

./package.json

``` json
{
  "scripts": {
    "test": "mocha --compilers es6:espower-babel/guess"
  },
  "devDependencies": {
    "espower-babel": "^3.1.1",
    "mocha": "^2.2.5",
    "power-assert": "^0.11.0"
  }
}
```

./src/index.es6

``` js
export default 'foo'
```

./test/index.es6

``` js
import assert from 'power-assert';
import api from '../src';

describe('API',()=>{
  it('index.es6 loaded',()=>{
    assert(api === 'foo');
  });
});
```

`./src/index.es6`が読み込まれず、テストは失敗します。

``` bash
$ npm test

> mocha --compilers es6:espower-babel/guess

module.js:338
    throw err;
          ^
Error: Cannot find module '../src'
```
