### PR TITLE
Breaking Change: update to Babel 6 & babel-plugin-espower 2.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "stage": 0
+  "presets": ["es2015", "stage-3"],
+  "plugins": ["transform-es2015-modules-commonjs"]
 }

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ require('espower-babel')({
 
 **Caution**:
  
-Babel 6 no transform by default.
+Babel 6 has not transform by default.
 It means that you must set babel config by `.babelrc` file or `babelrc` option.
 
 ### Transform all files with Babel **by default**

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ e.g.)
 ```js
 require('espower-babel')({
     babelrc: {
-        "presets": ["es2015", "stage-3"],
+        "presets": ["es2015"],
         "plugins": ["transform-es2015-modules-commonjs"]
     }
 })

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See the power-assert output appears!
 
 ## HOW TO USE
 
-### Zero-config mode
+### Zero-config mode(for testing)
 
 If your tests are located on `'test/**/*.js'`, just run mocha with `--compilers js:espower-babel/guess`
 
@@ -161,15 +161,21 @@ Babel has many transform options.
 
 `espower-babel` read `${cwd}/.babelrc` if exists.
 
-also can manually configure babel transform options.
+Also, you can manually configure babel transform options.
 
 ```js
 require('espower-babel')({
     babelrc: {
-        stage: 0
+        "presets": ["es2015", "stage-3"],
+        "plugins": ["transform-es2015-modules-commonjs"]
     }
 })
 ```
+
+**Caution**:
+ 
+Babel 6 no transform by default.
+It means that you must set babel config by `.babelrc` file or `babelrc` option.
 
 ### Transform all files with Babel **by default**
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Babel has many transform options.
 
 Also, you can manually configure babel transform options.
 
+e.g.)
+
 ```js
 require('espower-babel')({
     babelrc: {
@@ -180,6 +182,8 @@ It means that you must set babel config by `.babelrc` file or `babelrc` option.
 ### Transform all files with Babel **by default**
 
 Do limit transform files by setting `babelrc`
+
+e.g.)
 
 ```js
 require('espower-babel')({

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ require('espower-babel')({
 
 **Caution**:
  
-Babel 6 has not transform by default.
+Babel 6 does not transform your code by default. 
 It means that you must set babel config by `.babelrc` file or `babelrc` option.
 
 ### Transform all files with Babel **by default**

--- a/package.json
+++ b/package.json
@@ -33,15 +33,19 @@
     "url": "https://github.com/power-assert-js/espower-babel/issues"
   },
   "dependencies": {
-    "babel-core": "^5.0",
-    "babel-plugin-espower": "^1.0.0",
-    "minimatch": "^2.0.1",
-    "source-map-support": "^0.2.10",
+    "babel-core": "^6.0.0",
+    "babel-plugin-espower": "^2.0.0",
+    "minimatch": "^3.0.0",
+    "source-map-support": "^0.3.3",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.1.18",
+    "babel-polyfill": "^6.1.19",
+    "babel-preset-es2015": "^6.1.18",
+    "babel-preset-stage-3": "^6.1.18",
     "expect.js": "^0.3.1",
     "mocha": "^2.1.0",
-    "power-assert": "^0.11.0"
+    "power-assert": "^1.1.0"
   }
 }

--- a/test/tobe_instrumented/es7_test.js
+++ b/test/tobe_instrumented/es7_test.js
@@ -1,11 +1,10 @@
-require("babel-core/polyfill")
+require("babel-polyfill")
 
 let assert = require('power-assert')
 
 describe("ES7 async/await", ()=>{
   it("works", async()=>{
-    let ok = await Promise.resolve("OK")
 
-    assert(`${ok}` === "OK")
+    assert(await Promise.resolve("OK") === "OK")
   })
 })

--- a/test_loader/espower-traceur-loader.js
+++ b/test_loader/espower-traceur-loader.js
@@ -20,6 +20,7 @@ require('..')({
         ]
     },
     babelrc: {
-        stage: 0
+        "presets": ["es2015", "stage-3"],
+        "plugins": ["transform-es2015-modules-commonjs"]
     }
 });


### PR DESCRIPTION
Babel 6 has many many breaking changes.
So, to update to Babel 6 and espower-babel break backword compatible too.

Ref:
https://github.com/power-assert-js/babel-plugin-espower/releases/tag/v2.0.0
http://babeljs.io/blog/2015/10/29/6.0.0/

close #21 
