### PR TITLE
Fixed an issue where espower-babel/guess didn't work when required in gulpfile.js

### DIFF
--- a/guess.js
+++ b/guess.js
@@ -12,7 +12,7 @@ var path = require('path'),
 // such as `mocha --compilers <extension>:espower-babel/guess`,
 // override extension with the specified one.
 process.argv.forEach(function (arg) {
-    if (!~arg.indexOf(':')) {
+    if (arg.indexOf(':') === -1) {
         return;
     }
 

--- a/guess.js
+++ b/guess.js
@@ -1,3 +1,4 @@
+const COMPILER_NAME = require('./package.json').name + '/guess';
 var path = require('path'),
     resolveBabelrc = require('./lib/babelrc-util').resolveBabelrc,
     pattern = 'test/**/*.js',
@@ -6,20 +7,40 @@ var path = require('path'),
     babelrc,
     extension = '.js';
 
-// Override extension via (eg: `mocha --compilers <extension>:espower-babel/guess`)
+// When guess.js is loaded in a process
+// with an argument like <extension>:espower-babel/guess,
+// such as `mocha --compilers <extension>:espower-babel/guess`,
+// override extension with the specified one.
 process.argv.forEach(function (arg) {
-    // <extension>:espower-babel/guess
-    var args = arg.split(':');
-    if (args.length <= 1) {
+    if (!~arg.indexOf(':')) {
         return;
     }
-    var filePath = args[1];
-    var compilerFilePath = require.resolve(filePath);
-    var compilerFileExtension = args[0];
-    if (compilerFilePath !== module.filename) {
+
+    var parts = arg.split(':');
+    var ext = parts[0];
+    var compilerPath = parts[1];
+
+    // We should handle the relative path `./guess`
+    // to make our very own tests work.
+    if (compilerPath === './guess') {
+        var compilerFullPath;
+
+        try {
+            compilerFullPath = require.resolve(compilerPath);
+        } catch(err) {}
+
+        if (compilerFullPath !== module.filename) {
+            return;
+        }
+
+        compilerPath = COMPILER_NAME;
+    }
+
+    if (compilerPath !== COMPILER_NAME) {
         return;
     }
-    extension = '.' + compilerFileExtension;
+
+    extension = '.' + ext;
 });
 
 packageData = require(path.join(process.cwd(), 'package.json'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,15 @@
+/**
+ * gulpfile.js for ./test/issues/24
+ */
+var gulp = require('gulp');
+var mocha = require('gulp-mocha');
+
+// Since the `--compiers` option is not available in gulp-mocha,
+// registering a require hook is needed to make Mocha work with espower-babel.
+require('./guess');
+
+gulp.task('test:issue-#24', function() {
+  // This gulp task is expected to run a espowered Mocha test successfully.
+  return gulp.src('./test/person_test.js')
+    .pipe(mocha());
+});

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js && mocha test/issues/17 --compilers es6:./guess"
+    "test": "mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js && mocha test/issues/17 --compilers es6:./guess && mocha test/issues/24 --compilers js:./guess"
   },
   "directories": {
     "test": "test/"
@@ -45,6 +45,8 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-stage-3": "^6.1.18",
     "expect.js": "^0.3.1",
+    "gulp": "^3.9.0",
+    "gulp-mocha": "^2.2.0",
     "mocha": "^2.1.0",
     "power-assert": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js && mocha test/issues/17 --compilers es6:./guess && mocha test/issues/24 --compilers js:./guess"
+    "test": "mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js && mocha test/issues/17 --compilers es6:./guess && mocha test/issues/24 --compilers js:./guess --timeout 5000"
   },
   "directories": {
     "test": "test/"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js && mocha test/issues/17 --compilers es6:./guess && mocha test/issues/24 --compilers js:./guess --timeout 5000"
+    "test": "mocha --require './guess' test/**/*.js && mocha --require './test_loader/espower-traceur-loader' test/**/*.js && mocha test/issues/17 --compilers es6:./guess && mocha test/issues/24 --compilers js:./guess --timeout 15000"
   },
   "directories": {
     "test": "test/"

--- a/test/issues/24/gulpfile.js
+++ b/test/issues/24/gulpfile.js
@@ -6,7 +6,7 @@ var mocha = require('gulp-mocha');
 
 // Since the `--compiers` option is not available in gulp-mocha,
 // registering a require hook is needed to make Mocha work with espower-babel.
-require('./guess');
+require('../../../guess');
 
 gulp.task('test:issue-#24', function() {
   // This gulp task is expected to run a espowered Mocha test successfully.

--- a/test/issues/24/index.js
+++ b/test/issues/24/index.js
@@ -3,7 +3,13 @@ import { spawn } from 'child_process';
 
 describe('Gulp', () => {
   it('can run a task whose name contains a colon', (done) => {
-    const gulp = spawn('gulp', ['test:issue-#24']);
+    const gulp = spawn('gulp', [
+      '--gulpfile',
+      './test/issues/24/gulpfile.js',
+      '--cwd',
+      '.',
+      'test:issue-#24'
+    ]);
 
     gulp.on('exit', (code) => {
       assert(code === 0);

--- a/test/issues/24/index.js
+++ b/test/issues/24/index.js
@@ -1,0 +1,13 @@
+import assert from 'power-assert';
+import { spawn } from 'child_process';
+
+describe('Gulp', () => {
+  it('can run a task whose name contains a colon', (done) => {
+    const gulp = spawn('gulp', ['test:issue-#24']);
+
+    gulp.on('exit', (code) => {
+      assert(code === 0);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Overview

This PR fixes an issue where process.argv sniffing prevented the require hook from working under certain envs by making the sniffing more strict and accurate.
## The issue details

When espower-babel/guess require hook was invoked by a process with an argument containing ':', guess.js failed to `require.resolve()` and threw an error.
For example, when I executed the following command, it ended with the following error message.

**Command line**

``` sh
$ gulp test:e2e
```

**gulpfile.babel.js**

``` javascript
import gulp from 'gulp';
import mocha from 'gulp-mocha';
import {} from 'espower-babel/guess';

const paths = {
  e2e: './test/e2e/**/*.spec.js',
};

gulp.task('test:e2e', () =>
  gulp.src(paths.e2e)
    .pipe(mocha({
      timeout: 10000,
    }))
);
```

**Error message**

``` sh
$ gulp test:e2e

[21:46:30] Requiring external module babel-core/register
module.js:340
    throw err;
    ^

Error: Cannot find module 'e2e'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.require.resolve (module.js:389:19)
    at /Users/***/workspace/e2e-sample/node_modules/espower-babel/guess.js:17:36
    at Array.forEach (native)
    at Object.<anonymous> (/Users/***/workspace/e2e-sample/node_modules/espower-babel/guess.js:10:14)
    at Module._compile (module.js:425:26)
    at Module._extensions..js (module.js:432:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/***/workspace/e2e-sample/node_modules/babel-register/lib/node.js:138:7)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
```
